### PR TITLE
Enable response compression (Brotli + Gzip Optimal)

### DIFF
--- a/OregonTilth.API/Startup.cs
+++ b/OregonTilth.API/Startup.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,8 @@ using OregonTilth.API.Services.Hierarchy;
 using OregonTilth.EFModels.Entities;
 using Serilog;
 using System;
+using System.IO.Compression;
+using System.Linq;
 using System.Net.Http;
 using OregonTilth.API.Services.Logging;
 using OregonTilth.API.Services.SitkaSmtpClientService;
@@ -54,6 +57,16 @@ namespace OregonTilth.API
                         }
                     }
                 });
+
+            services.AddResponseCompression(options =>
+            {
+                options.EnableForHttps = true;
+                options.Providers.Add<BrotliCompressionProvider>();
+                options.Providers.Add<GzipCompressionProvider>();
+                options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[] { "application/json" });
+            });
+            services.Configure<BrotliCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
+            services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
 
             services.Configure<FrescaConfiguration>(Configuration);
 
@@ -117,6 +130,7 @@ namespace OregonTilth.API
                 app.UseHsts();
             }
             app.UseHttpsRedirection();
+            app.UseResponseCompression();
             app.UseSerilogRequestLogging(opts =>
             {
                 opts.EnrichDiagnosticContext = LogHelper.EnrichFromRequest;


### PR DESCRIPTION
## Summary
- Adds `Microsoft.AspNetCore.ResponseCompression` to `OregonTilth.API`
- Brotli + Gzip providers (browsers prefer Brotli; Gzip is the universal fallback)
- Compression level set to `Optimal` — small server CPU cost for ~30% smaller output vs `Fastest`

Cribbed from the same change on Qanat ([esassoc/qanat@753b0b7](https://github.com/esassoc/qanat/commit/753b0b70986667637b3c2776773496381599317b)), which measured ~10x smaller JSON payloads on the worst-case page. Production gains scale with network bandwidth savings on every endpoint with a non-trivial response and should also cut Azure egress costs.

## Test plan
- [ ] Smoke-test a heavy endpoint locally and confirm `Content-Encoding: br` (or `gzip`) on the response
- [ ] Verify swagger UI and health checks still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)