### PR TITLE
Fix SPA cache headers so deploys do not strand stale index.html

### DIFF
--- a/OregonTilth.Web/Startup.cs
+++ b/OregonTilth.Web/Startup.cs
@@ -1,12 +1,16 @@
+using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Rewrite;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
 
 namespace Fresca.Web
@@ -59,12 +63,41 @@ namespace Fresca.Web
                 if (context.Response.StatusCode == 404 && !Path.HasExtension(context.Request.Path.Value))
                 {
                     context.Request.Path = "/index.html";
+                    context.Response.StatusCode = 200;
                     await next();
                 }
             });
 
             app.UseDefaultFiles();
-            app.UseStaticFiles();
+            app.UseStaticFiles(new StaticFileOptions { OnPrepareResponse = SetSpaCacheHeaders });
+        }
+
+        // Hashed Angular bundles can be cached forever because their URLs change every build.
+        // Stable URLs, especially index.html, must revalidate so the browser does not keep
+        // a stale SPA shell that points at deleted bundle filenames.
+        // First alternative `-[A-Z0-9]{8,}` matches esbuild's `name-HASH.ext` (uppercase base32).
+        // Second alternative `\.[a-f0-9]{16,}` matches classic webpack's `name.HASH.ext` (lowercase
+        // hex, default 16 chars). Both alternatives are narrow enough to avoid false-positives on
+        // ordinary lowercase asset names (e.g., `account-activity-screenshot.png`).
+        private static readonly Regex HashedAssetPattern = new(@"(?:-[A-Z0-9]{8,}|\.[a-f0-9]{16,})\.[a-z0-9]+$", RegexOptions.Compiled);
+
+        private static void SetSpaCacheHeaders(StaticFileResponseContext context)
+        {
+            var headers = context.Context.Response.GetTypedHeaders();
+            var fileName = Path.GetFileName(context.File.Name);
+            if (HashedAssetPattern.IsMatch(fileName))
+            {
+                headers.CacheControl = new CacheControlHeaderValue
+                {
+                    Public = true,
+                    MaxAge = TimeSpan.FromDays(365),
+                    Extensions = { new NameValueHeaderValue("immutable") }
+                };
+            }
+            else
+            {
+                headers.CacheControl = new CacheControlHeaderValue { NoCache = true };
+            }
         }
     }
 


### PR DESCRIPTION
Port of [qanat#894](https://github.com/esassoc/qanat/pull/894).

After the SPA fallback rewrites a 404 to `/index.html`, also set `Response.StatusCode = 200` so the SPA shell is delivered cleanly. Configure `UseStaticFiles` with an `OnPrepareResponse` callback that sets `Cache-Control: public, max-age=31536000, immutable` on hashed bundles and `Cache-Control: no-cache` on everything else (notably `index.html`), so a client that already cached the previous deploy's `index.html` re-fetches on the next page load instead of trying to load deleted hashed chunks.

The combined regex `(?:-[A-Z0-9]{8,}|\.[a-f0-9]{16,})\.[a-z0-9]+$` matches both Angular esbuild's uppercase base32 hashes and the classic webpack builder's lowercase hex hashes — verified against real bundle filenames from across esassoc apps.

**Drift from qanat:** Namespace `Fresca.Web` preserved (legacy). Combined regex's webpack alternative covers OregonTilth's lowercase-hex hashes.

## Test plan
- [ ] Deploy to QA, hard-refresh browser, confirm `index.html` returns `Cache-Control: no-cache`
- [ ] Confirm hashed bundles return `Cache-Control: public, max-age=31536000, immutable`
- [ ] Confirm a deep SPA route loads with HTTP 200 not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
