### PR TITLE
fix(ci): publish the prod BacPac under a stable filename

### DIFF
--- a/Build/backup-db.yml
+++ b/Build/backup-db.yml
@@ -40,13 +40,32 @@ jobs:
       SqlPassword: '$(kv-sqlAdministratorPassword)'
       DeploymentAction: Export
 
-  - publish: '$(export.SqlDeploymentOutputFile)'
+  # SqlAzureDacpacDeployment@1 names its Export output '<database>_<new guid>.bacpac' and offers
+  # no input to change it, so SqlDeploymentOutputFile is a different filename on every run. 2
+  # consumers resolve this backup by the exact name '<databaseName>.bacpac' — the DB deploy
+  # stage's bacpacFile in azure-pipelines.yml and the local dev blob download in
+  # DatabaseDownload.ps1 — and none of them can match a per-run guid. Stage it under the stable
+  # name here so both the artifact and the blob keep that contract; publishing the task's path
+  # directly also meant every run uploaded a new blob instead of replacing the previous one.
+  - task: PowerShell@2
+    displayName: 'Stage BacPac under a stable filename'
+    inputs:
+      targetType: inline
+      failOnStderr: true
+      script: |
+        $exported = "$(export.SqlDeploymentOutputFile)"
+        $staged = Join-Path "$(Agent.TempDirectory)" "$(databaseName).bacpac"
+        Write-Host "Export task produced: $exported"
+        Copy-Item -LiteralPath $exported -Destination $staged -Force
+        Write-Host "Staged for publish as: $staged"
+
+  - publish: '$(Agent.TempDirectory)/$(databaseName).bacpac'
     artifact: bacpac
 
   - task: AzureFileCopy@6
     displayName: 'Copy BacPac to QA Blob storage'
     inputs:
-      SourcePath: '$(export.SqlDeploymentOutputFile)'
+      SourcePath: '$(Agent.TempDirectory)/$(databaseName).bacpac'
       azureSubscription: '$(AzureQAServiceConnection)' #Should be QA Service Connection
       Destination: 'AzureBlob'
       storage: '$(qaStorageAccountName)'


### PR DESCRIPTION
## Problem

`SqlAzureDacpacDeployment@1` changed on 2026-07-14 ([Microsoft PR #22360](https://github.com/microsoft/azure-pipelines-tasks/pull/22360)) to name its `Export` output `<database>_<new guid>.bacpac` so concurrent exports cannot collide. The task **auto-updates within its major version**, so this reached our agents with no change on our side and no pipeline edit to review.

`Build/backup-db.yml` passed `$(export.SqlDeploymentOutputFile)` straight through to both the pipeline artifact and the blob upload, so since that date every backup run emits a guid-named BacPac.

Everything downstream resolves this backup as `<databaseName>.bacpac` and cannot match a per-run guid:

- `bacpacFile` in `azure-pipelines.yml` (DB deploy stage) — fails loudly with `No files were found to deploy with search pattern`
- `DatabaseDownload.ps1` (local dev DB refresh) — every developer's `DatabaseDownload` 404s

## Fix

A `PowerShell@2` step stages the export to `$(Agent.TempDirectory)/$(databaseName).bacpac`; the `publish` and the `AzureFileCopy` `SourcePath` both point at that stable path. The task offers no input to control its output name, so staging is the only place to restore the contract.

This also stops each backup run from *adding* a new blob to `prod-backup` instead of replacing the previous one.

## Provenance

Ported from esassoc/Beacon@2c8e3b89, where this was diagnosed. Part of an org-wide rollout across every repo carrying the same templated backup pipeline — tracked in [compass `indexes/bacpac-stable-filename.md`](https://github.com/esassoc/compass/blob/master/indexes/bacpac-stable-filename.md).

## Follow-up not covered by this PR

- The `prod-backup` container has been accumulating guid-named orphan blobs since 2026-07-14 and likely needs a cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
